### PR TITLE
Replace tabs with spaces in testling template

### DIFF
--- a/lib/testling/package.json
+++ b/lib/testling/package.json
@@ -19,11 +19,11 @@
   {{/cmd}}
   "scripts": {
     "test": "if [ \"${TRAVIS}\" ]; then npm run test-ci; else npm run test-local; fi",
-		"test-local": "tape \"./test/*.js\" | tap-spec",
-		"test-ci": "npm run test-local && xvfb-run npm run test-browsers",
-		"test-cov": "istanbul cover --dir ./reports/coverage --report lcov tape -- \"./test/*.js\"",
-		"test-browsers": "browserify ./test/*.js | testling | tap-spec",
-		"coverage": "istanbul cover --dir ./reports/codecov/coverage --report lcovonly tape -- \"./test/*.js\" && cat ./reports/codecov/coverage/lcov.info | codecov && rm -rf ./reports/codecov"
+    "test-local": "tape \"./test/*.js\" | tap-spec",
+    "test-ci": "npm run test-local && xvfb-run npm run test-browsers",
+    "test-cov": "istanbul cover --dir ./reports/coverage --report lcov tape -- \"./test/*.js\"",
+    "test-browsers": "browserify ./test/*.js | testling | tap-spec",
+    "coverage": "istanbul cover --dir ./reports/codecov/coverage --report lcovonly tape -- \"./test/*.js\" && cat ./reports/codecov/coverage/lcov.info | codecov && rm -rf ./reports/codecov"
   },
   "main": "./lib",
   "repository": {
@@ -37,7 +37,7 @@
   "dependencies": {},
   "devDependencies": {
     "browserify": "13.x.x",
-		"codecov": "1.x.x",
+    "codecov": "1.x.x",
     "istanbul": "^0.4.1",
     "jshint": "2.x.x",
     "jshint-stylish": "2.x.x",


### PR DESCRIPTION
`package.json` testling template still contains tabs. This pull request replaces them with spaces.
